### PR TITLE
feat(shop): add Send button placeholder to product cards

### DIFF
--- a/app/shop/[id]/page.tsx
+++ b/app/shop/[id]/page.tsx
@@ -19,7 +19,8 @@ import {
   Filter,
   LayoutGrid,
   TrendingUp,
-  ShoppingCart
+  ShoppingCart,
+  Send
 } from "lucide-react";
 import Link from "next/link";
 import { GoldCheck } from "@/components/GoldCheck";
@@ -553,6 +554,15 @@ const ShopProfilePage = () => {
                               className="p-2 rounded-full hover:bg-primary/10 hover:text-primary transition-colors"
                             >
                               <Share2 className="w-[18px] h-[18px]" />
+                            </button>
+                            <button 
+                              onClick={(e) => { 
+                                e.stopPropagation();
+                                // Placeholder for future functionality
+                              }}
+                              className="p-2 rounded-full hover:bg-primary/10 hover:text-primary transition-colors"
+                            >
+                              <Send className="w-[18px] h-[18px]" />
                             </button>
                           </div>
                         </div>

--- a/app/shop/page.tsx
+++ b/app/shop/page.tsx
@@ -18,7 +18,8 @@ import {
   Info,
   Plus,
   ArrowRight,
-  ShoppingCart
+  ShoppingCart,
+  Send
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -834,6 +835,18 @@ const ShopContent = () => {
                           >
                             <div className="p-2 rounded-full group-hover:bg-muted transition-colors">
                               <Share2 className="w-[18px] h-[18px]" />
+                            </div>
+                          </button>
+
+                          <button 
+                            onClick={(e) => { 
+                              e.stopPropagation();
+                              // Placeholder for future functionality
+                            }}
+                            className="flex items-center gap-2 group transition-colors hover:text-primary"
+                          >
+                            <div className="p-2 rounded-full group-hover:bg-primary/10 transition-colors">
+                              <Send className="w-[18px] h-[18px]" />
                             </div>
                           </button>
                         </div>


### PR DESCRIPTION
Add a Send button to product cards on both shop profile and shop listing pages. The button currently serves as a placeholder with no implemented functionality. This prepares for future messaging/sending features while maintaining consistent UI patterns.